### PR TITLE
pyFAI 0.21.0 changed pos0Range -> pos0_range

### DIFF
--- a/smi_analysis/remesh.py
+++ b/smi_analysis/remesh.py
@@ -86,6 +86,8 @@ def remesh_transmission(image, ai, bins=None, q_h_range=None, q_v_range=None, ma
                                               pos1=q_v,
                                               delta_pos1=np.ones_like(image) * (q_v_range[1] - q_v_range[0]) / bins[1],
                                               bins=bins,
+                                              pos0_range=q_h_range,
+                                              pos1_range=q_v_range,
                                               pos0Range=q_h_range,
                                               pos1Range=q_v_range,
                                               dummy=None,


### PR DESCRIPTION
Updating args to `splitBBox.histoBBox2d` to reflect recent changes in pyFAI (>= v0.21.0). Also leaving old arg names (e.g., `pos0Range`) to allow for backward compatibility for users with new smi-analysis package but old pyFAI version. 