### PR TITLE
Add inpainting kwargs support

### DIFF
--- a/smi_analysis/SMI_beamline.py
+++ b/smi_analysis/SMI_beamline.py
@@ -237,10 +237,11 @@ class SMI_geometry():
         else:
             raise Exception('scaling waxs images error')
 
-    def inpainting(self):
+    def inpainting(self, **kwargs):
         self.inpaints, self.mask_inpaints = integrate1D.inpaint_saxs(self.imgs,
                                                                      self.ai,
-                                                                     self.masks
+                                                                     self.masks,
+                                                                     **kwargs
                                                                      )
 
     def caking(self, radial_range=None, azimuth_range=None, npt_rad=500, npt_azim=500):

--- a/smi_analysis/integrate1D.py
+++ b/smi_analysis/integrate1D.py
@@ -3,7 +3,7 @@ from pyFAI.multi_geometry import MultiGeometry
 from pyFAI.ext import splitBBox
 
 
-def inpaint_saxs(imgs, ais, masks):
+def inpaint_saxs(imgs, ais, masks, **kwargs):
     """
     Inpaint the 2D image collected by the pixel detector to remove artifacts in later data reduction
 
@@ -19,7 +19,7 @@ def inpaint_saxs(imgs, ais, masks):
     inpaints, mask_inpaints = [], []
     for i, (img, ai, mask) in enumerate(zip(imgs, ais, masks)):
         inpaints.append(ai.inpainting(img.copy(order='C'),
-                                      mask))
+                                      mask, **kwargs))
         mask_inpaints.append(np.logical_not(np.ones_like(mask)))
 
     return inpaints, mask_inpaints

--- a/smi_analysis/integrate1D.py
+++ b/smi_analysis/integrate1D.py
@@ -179,8 +179,8 @@ def integrate_rad_gisaxs(img, q_par, q_per, bins=1000, radial_range=None, azimut
                                                delta_pos1=np.ones_like(img_mask) * (q_per[1] - q_per[0])/np.shape(
                                                    img_mask)[0],
                                                bins=bins,
-                                               pos0Range=np.array([np.min(tth_array), np.max(tth_array)]),
-                                               pos1Range=q_per,
+                                               pos0_range=np.array([np.min(tth_array), np.max(tth_array)]),
+                                               pos1_range=q_per,
                                                dummy=None,
                                                delta_dummy=None,
                                                mask=img_mask.mask
@@ -318,8 +318,8 @@ def cake_gisaxs(img, q_par, q_per, bins=None, radial_range=None, azimuth_range=N
                                                pos1=chi_array,
                                                delta_pos1=np.ones_like(img_mask) * (q_per[1] - q_per[0])/bins[1],
                                                bins=bins,
-                                               pos0Range=np.array([np.min(radial_range), np.max(radial_range)]),
-                                               pos1Range=np.array([np.min(azimuth_range), np.max(azimuth_range)]),
+                                               pos0_range=np.array([np.min(radial_range), np.max(radial_range)]),
+                                               pos1_range=np.array([np.min(azimuth_range), np.max(azimuth_range)]),
                                                dummy=None,
                                                delta_dummy=None,
                                                mask=img_mask.mask)

--- a/smi_analysis/remesh.py
+++ b/smi_analysis/remesh.py
@@ -88,8 +88,6 @@ def remesh_transmission(image, ai, bins=None, q_h_range=None, q_v_range=None, ma
                                               bins=bins,
                                               pos0_range=q_h_range,
                                               pos1_range=q_v_range,
-                                              pos0Range=q_h_range,
-                                              pos1Range=q_v_range,
                                               dummy=None,
                                               delta_dummy=None,
                                               allow_pos0_neg=True,

--- a/smi_analysis/remesh.py
+++ b/smi_analysis/remesh.py
@@ -86,6 +86,8 @@ def remesh_transmission(image, ai, bins=None, q_h_range=None, q_v_range=None, ma
                                               pos1=q_v,
                                               delta_pos1=np.ones_like(image) * (q_v_range[1] - q_v_range[0]) / bins[1],
                                               bins=bins,
+                                              pos0_range=q_h_range,
+                                              pos1_range=q_v_range,
                                               pos0Range=q_h_range,
                                               pos1Range=q_v_range,
                                               dummy=None,


### PR DESCRIPTION
Adding optional `**kwargs` to `smi.inpainting()` function in order to be able to pass optional arguments to `ai.inpainting`. This is helpful when performing Fourier analysis and need the inpainted image to be optimized (e.g., https://pyfai.readthedocs.io/en/master/usage/tutorial/Inpainting/Inpainting.html?highlight=inpainting).