### PR TITLE
CI: add a workflow to publish releases on PyPI

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,34 @@
+# This workflow will upload a Python Package using flit when a release is
+# created.  For more information see:
+# https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel twine setuptools
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: __token__
+          # The PYPI_PASSWORD must be a pypi token with the "pypi-" prefix with sufficient permissions to upload this package
+          # https://pypi.org/help/#apitoken
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          python setup.py sdist bdist_wheel
+          twine upload dist/*

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@
 h5py
 numpy
 pyFAI
-pygix
+pygix>=2022.11.14
 scipy
 xarray


### PR DESCRIPTION
Follows an approach from https://github.com/bluesky/databroker/blob/main/.github/workflows/publish-pypi.yml.